### PR TITLE
Fix circular import of Bluetooth components in coordinator

### DIFF
--- a/custom_components/philips_shaver/coordinator.py
+++ b/custom_components/philips_shaver/coordinator.py
@@ -12,13 +12,14 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.config_entries import ConfigEntry
 
-from . import (
-    bluetooth as shaver_bluetooth,
+from homeassistant.components.bluetooth import (
     BluetoothCallbackMatcher,
     BluetoothScanningMode,
     async_last_service_info,
     async_register_callback,
 )
+
+from . import bluetooth as shaver_bluetooth
 from .const import (
     CHAR_AMOUNT_OF_CHARGES,
     CHAR_AMOUNT_OF_OPERATIONAL_TURNS,


### PR DESCRIPTION
Correctly import BluetoothCallbackMatcher, BluetoothScanningMode, async_last_service_info, and async_register_callback from homeassistant.components.bluetooth instead of the relative module. This resolves a startup error in Home Assistant 2026.2.